### PR TITLE
metrics - allowing the selection of which metrics to include in the policy

### DIFF
--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -414,6 +414,14 @@ class MetricsOutput(Metrics):
         else:
             watch = utils.local_session(
                 self.ctx.session_factory).client('cloudwatch', region_name=self.region)
+
+        # NOTE filter metrics data by the metric name configured in the policy
+        # metrics = [m for m in metrics if m["Value"] > 0]
+        if hasattr(self.ctx.policy, "data") and "metrics" in self.ctx.policy.data:
+            metrics = [m for m in metrics if m["MetricName"] in self.ctx.policy.data["metrics"]]
+        if not metrics:
+            return
+
         return self.retry(
             watch.put_metric_data, Namespace=ns, MetricData=metrics)
 

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -303,6 +303,7 @@ def generate(resource_types=()):
                 'filters': {
                     'type': 'array'
                 },
+                'metrics': {'type': 'array'},
                 #
                 # TODO: source queries should really move under
                 # source. This was initially used for describe sources

--- a/c7n/structure.py
+++ b/c7n/structure.py
@@ -16,7 +16,7 @@ class StructureParser:
     required_policy_keys = {'name', 'resource'}
     allowed_policy_keys = {'name', 'resource', 'title', 'description', 'mode',
          'tags', 'max-resources', 'metadata', 'query',
-         'filters', 'actions', 'source', 'conditions',
+         'filters', 'actions', 'source', 'conditions', 'metrics',
          # legacy keys subject to deprecation.
          'region', 'start', 'end', 'tz', 'max-resources-percent',
          'comments', 'comment'}

--- a/docs/source/aws/usage.rst
+++ b/docs/source/aws/usage.rst
@@ -62,6 +62,8 @@ Typically, the following four metrics are included: ResourceCount, ResourceTime,
 ActionTime, and ApiCalls. To filter the metrics and save costs, you can specify a
 'metrics' item in the policy as shown below:
 
+.. code-block:: yaml
+
   policies:
     - name: list-ec2
       resource: ec2

--- a/docs/source/aws/usage.rst
+++ b/docs/source/aws/usage.rst
@@ -58,6 +58,16 @@ specify a region::
 When running the metrics in a centralized account or when centralizing to a specific
 region, additional account and region dimensions will be included.
 
+Typically, the following four metrics are included: ResourceCount, ResourceTime,
+ActionTime, and ApiCalls. To filter the metrics and save costs, you can specify a
+'metrics' item in the policy as shown below:
+
+  policies:
+    - name: list-ec2
+      resource: ec2
+      metrics:
+        - ResourceCount
+
 
 CloudWatch Logs
 ---------------

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -7,7 +7,7 @@ import threading
 import socket
 import sys
 from urllib.error import URLError, HTTPError
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from c7n.config import Bag, Config
 from c7n.exceptions import PolicyValidationError, InvalidOutputConfig
@@ -325,6 +325,13 @@ class OutputMetricsTest(BaseTest):
         self.assertTrue(isinstance(sink, aws.MetricsOutput))
         sink.put_metric('ResourceCount', 101, 'Count')
         sink.flush()
+
+        # Test metrics filter when 'metrics' is present in policy
+        policy['data'] = {'metrics':['ResourceCount']}
+        with patch("botocore.client.BaseClient._make_api_call") as aws_api:
+            sink._put_metrics("ns", [{'MetricName': 'Calories'}, {'MetricName': 'ResourceCount'}])
+            assert aws_api.call_args[0][0] == "PutMetricData"
+            assert aws_api.call_args[0][1]["MetricData"] == [{'MetricName': 'ResourceCount'}]
 
 
 class OutputLogsTest(BaseTest):

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -332,6 +332,10 @@ class OutputMetricsTest(BaseTest):
             sink._put_metrics("ns", [{'MetricName': 'Calories'}, {'MetricName': 'ResourceCount'}])
             assert aws_api.call_args[0][0] == "PutMetricData"
             assert aws_api.call_args[0][1]["MetricData"] == [{'MetricName': 'ResourceCount'}]
+            assert aws_api.call_count == 1
+            # Exclude all metrics
+            sink._put_metrics("ns", [])
+            assert aws_api.call_count == 1
 
 
 class OutputLogsTest(BaseTest):


### PR DESCRIPTION
Typically, when a policy is executed, it puts the following four metrics: ResourceCount, ResourceTime, ActionTime, and ApiCalls. For a small/medium-sized cloud environment, this could result in 200 policies * 100 accounts * 4 metrics = 80,000 metrics.
```
Tiered price for: 80000 metrics
10000 metrics x 0.3000000000 USD = 3000.00 USD
70000 metrics x 0.1000000000 USD = 7000.00 USD
Total tier cost: 3000.00 USD + 7000.00 USD = 10000.00 USD (Metrics cost (includes custom metrics))
CloudWatch Metrics cost (monthly): 10,000.00 USD
```
Of course, if the policies are executed only twice a day, the cost should be cut down to **$800**. Although this amount may not be significant, it would still be beneficial to provide users with the option to choose which metrics to include, allowing them to reduce costs to some extent, eg, $200 a month for recording ResourceCount only.

```
  policies:
    - name: list-ec2
      resource: ec2
      metrics:
        - ResourceCount
```

Ref:
https://github.com/cloud-custodian/cloud-custodian/pull/8667